### PR TITLE
Fix ion-input attribute warning

### DIFF
--- a/src/ion-mask/ion-mask.component.html
+++ b/src/ion-mask/ion-mask.component.html
@@ -8,7 +8,7 @@
       [type]="getAttrTypeInput()"
       [disabled]="disabled ? '' : null"
       (keyup)="keyUpEvent($event)"
-      (blur)="onBlur($event)"
+      (ionBlur)="onBlur($event)"
       (change)="onChange($event)"
       [(ngModel)]="valueIonInput"
       [attr.clearInput]="getAttrClearInput()"


### PR DESCRIPTION
**Reason for Pull Request**

Received following warning while using the mask: 
`WARN: '(blur) is deprecated in ion-input, use (ionBlur) instead'`
